### PR TITLE
Modifications for specialization of floats

### DIFF
--- a/src/PrevirtTypes.cpp
+++ b/src/PrevirtTypes.cpp
@@ -349,6 +349,10 @@ namespace previrt
 	      ConstantInt::get(M.getContext(),
 			       APInt(buffer.int_().bits(), buffer.int_().value(), 16));
 	  break;
+      case proto::F:
+	  concreteValue =
+	      ConstantFP::get(type, StringRef(buffer.float_().data()));
+	  break;
       case proto::S:
 	  assert(buffer.str().IsInitialized());
 	  if (!buffer.str().cstr())
@@ -399,7 +403,8 @@ namespace previrt
     return buffer.type() == proto::I || // Integer
       buffer.type() == proto::G || // Global
       buffer.type() == proto::N || // Null
-      buffer.type() == proto::S; // String
+      buffer.type() == proto::S || // String
+      buffer.type() == proto::F;  // float
   }
 
   bool
@@ -419,6 +424,8 @@ namespace previrt
     case proto::I:
       assert(buffer.int_().IsInitialized());
       return std::string("0x") + buffer.int_().value();
+    case proto::F:
+      return buffer.float_().data();
     case proto::S: {
       assert(buffer.str().IsInitialized());
       if (!buffer.str().cstr())


### PR DESCRIPTION
The specialization do not appear to work for the floats before these modifications. We have tested that OCCAM specialize all the data types ,listed in PrevirtTypes.cpp, after these modifications.